### PR TITLE
Session and HTML tag improvements

### DIFF
--- a/lib/miniweb/template/tag/html.ex
+++ b/lib/miniweb/template/tag/html.ex
@@ -55,13 +55,20 @@ defmodule Miniweb.Template.Tag.Html do
 
   defp prop(context, path) do
     if String.contains?(path, ".") do
-      path = String.split(path, ".")
+      path =
+        path
+        |> String.split(".")
+        |> Enum.reject(&blank?/1)
 
       get_in(context.iteration_vars, path) || get_in(context.counter_vars, path)
     else
       path
     end
   end
+
+  defp blank?(""), do: true
+  defp blank?(nil), do: true
+  defp blank?(_), do: false
 
   defp format(true), do: "Yes"
   defp format(false), do: "No"


### PR DESCRIPTION
# Description

A couple of minor improvements:

* the `html` is now slightly smarter. If a path with no `.` separator is provided, then indirection won't be applied. This applies for most simple use cases.
* the session data is now injected into the template data. 